### PR TITLE
version

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.16.2-otp-26
-erlang 26.2.2
+elixir 1.17.1-otp-27
+erlang 27.1

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Este guia é para quem deseja rodar o projeto localmente em ambiente de desenvol
 Para fazer contribuições, siga as instruções em [CONTRIBUTING.md](CONTRIBUTING.md).
 ## Pré-requisitos
 
-* [Elixir](https://elixir-lang.org/install.html) 1.16.2 (compiled with Erlang/OTP 26)
+* [Elixir](https://elixir-lang.org/install.html) 1.17.1 (compiled with Erlang/OTP 27)
 * [Erlang](https://www.erlang.org/downloads)
 * [Node.js](https://nodejs.org/)
 * [Docker + Docker Compose](https://docs.docker.com/compose/install/)


### PR DESCRIPTION
This pull request updates the Elixir and Erlang versions used in the project to align with newer releases. The changes ensure compatibility and reflect the updated requirements in the documentation.

Version updates:

* [`.tool-versions`](diffhunk://#diff-751af1a340658c7b8176fe32d7db9fadbe15d1d075daba1919a91df04155bc70L1-R2): Updated Elixir from `1.16.2-otp-26` to `1.17.1-otp-27` and Erlang from `26.2.2` to `27.1`.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L7-R7): Updated the Elixir version in the prerequisites section to match the new version (`1.17.1` compiled with Erlang/OTP 27).